### PR TITLE
update multi-project dependency fetch gradle 8.11

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
@@ -100,8 +100,8 @@ public record SpecContextImpl(List<PuzzleModJson> modDependencies, List<PuzzleMo
 	}
 
 	private static Stream<Project> getDependentProjects(Project project) {
-		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
-		final Stream<Project> compileProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project, project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+		final Stream<Project> compileProjects = getLoomProjectDependencies(project, project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
 
 		return Stream.concat(runtimeProjects, compileProjects)
 				.distinct();
@@ -166,19 +166,19 @@ public record SpecContextImpl(List<PuzzleModJson> modDependencies, List<PuzzleMo
 
 	// Returns a list of Loom Projects found in both the runtime and compile classpath
 	private static Stream<Project> getCompileRuntimeProjectDependencies(Project project) {
-		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
-		final List<Project> compileProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)).toList();
+		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project, project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+		final List<Project> compileProjects = getLoomProjectDependencies(project, project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)).toList();
 
 		return runtimeProjects
 				.filter(compileProjects::contains); // Use the intersection of the two configurations.
 	}
 
 	// Returns a list of Loom Projects found in the provided Configuration
-	private static Stream<Project> getLoomProjectDependencies(Configuration configuration) {
+	private static Stream<Project> getLoomProjectDependencies(Project project, Configuration configuration) {
 		return configuration.getAllDependencies()
 				.withType(ProjectDependency.class)
 				.stream()
-				.map(GradleUtils::getDependencyProject)
+				.map((d) -> project.project(d.getPath()))
 				.filter(GradleUtils::isLoomProject);
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
@@ -25,14 +25,13 @@
 package net.fabricmc.loom.util.gradle;
 
 import java.io.File;
-import java.lang.reflect.Field;
+
 import java.util.function.Consumer;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.ProjectDependency;
+
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
-import org.gradle.api.internal.catalog.DelegatingProjectDependency;
+
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.slf4j.Logger;
@@ -97,32 +96,5 @@ public final class GradleUtils {
 		return property.getAsFile().get();
 	}
 
-	// Get the project from the field with reflection to suppress the deprecation warning.
-	// If you hate it find a solution yourself and make a PR, I'm getting a bit tired of chasing Gradle updates
-	public static Project getDependencyProject(ProjectDependency projectDependency) {
-		if (projectDependency instanceof DefaultProjectDependency) {
-			try {
-				final Class<DefaultProjectDependency> clazz = DefaultProjectDependency.class;
-				final Field dependencyProject = clazz.getDeclaredField("dependencyProject");
-				dependencyProject.setAccessible(true);
-				return (Project) dependencyProject.get(projectDependency);
-			} catch (NoSuchFieldException | IllegalAccessException e) {
-				LOGGER.warn("Failed to reflect DefaultProjectDependency", e);
-			}
-		} else if (projectDependency instanceof DelegatingProjectDependency) {
-			try {
-				final Class<DelegatingProjectDependency> clazz = DelegatingProjectDependency.class;
-				final Field delgeate = clazz.getDeclaredField("delegate");
-				delgeate.setAccessible(true);
-				return getDependencyProject((ProjectDependency) delgeate.get(projectDependency));
-			} catch (NoSuchFieldException | IllegalAccessException e) {
-				LOGGER.warn("Failed to reflect DelegatingProjectDependency", e);
-			}
-		}
 
-		// Just fallback and trigger the warning, this will break in Gradle 9
-		final Project project = projectDependency.getDependencyProject();
-		LOGGER.warn("Loom was unable to suppress the deprecation warning for ProjectDependency#getDependencyProject, if you are on the latest version of Loom please report this issue to the Loom developers and provide the error above, this WILL stop working in a future Gradle version.");
-		return project;
-	}
 }


### PR DESCRIPTION
This was a part of commit e387514 update to gradle 8.11. This PR just includes the fix for project dependency fetches failing during gradle build. Error was something like Failure to reflect ...getProjectDependency() during the sub project build.

I only tested with my local multi project build. but the changes are what the main fabric loom is still using.

Im not sure if it would work but it might be better to close this one and just use the commit above and push all the changes.